### PR TITLE
Fix for 'Cannot read property 'command' of undefined', switch to new …

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ var path      = require('path')
 var astw      = require('astw')
 
 exports.activate = function() {
-  atom.workspaceView.command('node-resolver:open-selected-dependencies', function() {
-    var editor = atom.workspace.getActiveEditor()
+  atom.commands.add('atom-text-editor','node-resolver:open-selected-dependencies', function() {
+    var editor = atom.workspace.getActiveTextEditor()
     var ranges = editor.getSelectedBufferRanges().slice()
     var buffer = editor.getBuffer()
     var fpn = editor.getPath()
@@ -50,12 +50,12 @@ exports.activate = function() {
       }
 
       if (!included) return
-
+      
       resolve(dst, {
         basedir: dir
       }, function(err, result) {
         if (err) throw err
-        return atom.workspaceView.open(result)
+        return atom.workspace.open(result)
       })
     })
   })


### PR DESCRIPTION
Not an atom package dev per ce. 
But workspaceView is deprecated, switching to the appropriate calls proposed in the new atom API seems to fix the issue. 
